### PR TITLE
chore: Replace hardcoded version with automatic git tag versioning

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -376,27 +376,21 @@ pytest tests/ -v
 
 ## Releasing a New Version
 
-1. **Bump the version** in `pyproject.toml`:
-   ```toml
-   [project]
-   version = "x.y.z"
-   ```
+The version is derived automatically from git tags via `hatch-vcs` — no manual version bumps needed.
 
-2. **Commit and push** the version bump to `main`.
-
-3. **Create a GitHub Release** via the GitHub UI (or `gh release create`):
+1. **Create a GitHub Release** via the GitHub UI (or `gh release create`):
    - Set the tag to `vx.y.z` (e.g. `v0.2.0`)
    - Write a release title and notes summarising changes
    - Click **Publish release**
 
-4. **The publish workflow fires automatically.** The [`Publish to PyPI`](.github/workflows/publish.yml) GitHub Actions workflow triggers on release publication, builds the package, and pushes it to PyPI via [Trusted Publisher (OIDC)](https://docs.pypi.org/trusted-publishers/) — no API token required.
+2. **The publish workflow fires automatically.** The [`python-release.yml`](.github/workflows/python-release.yml) GitHub Actions workflow triggers on release publication, builds the package (reading the version from the git tag), and pushes it to PyPI via [Trusted Publisher (OIDC)](https://docs.pypi.org/trusted-publishers/) — no API token required.
 
-5. **Verify** the new version appears on [https://pypi.org/project/gtfs-diff-engine](https://pypi.org/project/gtfs-diff-engine) and is installable:
+3. **Verify** the new version appears on [https://pypi.org/project/gtfs-diff-engine](https://pypi.org/project/gtfs-diff-engine) and is installable:
    ```bash
    pip install gtfs-diff-engine==x.y.z
    ```
 
-> **One-time PyPI setup:** A maintainer must configure the repository as a Trusted Publisher on PyPI before the first automated release. Go to the [gtfs-diff-engine PyPI project](https://pypi.org/manage/project/gtfs-diff-engine/settings/publishing/), add a publisher for `MobilityData/gtfs-diff-engine`, workflow `publish.yml`, environment `pypi`.
+> **One-time PyPI setup:** A maintainer must configure the repository as a Trusted Publisher on PyPI before the first automated release. Go to the [gtfs-diff-engine PyPI project](https://pypi.org/manage/project/gtfs-diff-engine/settings/publishing/), add a publisher for `MobilityData/gtfs-diff-engine`, workflow `python-release.yml`, environment `pypi`.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ testpaths = ["tests"]
 [tool.ruff]
 target-version = "py310"
 src = ["src", "tests"]
-exclude = ["src/gtfs_diff/models.py"]
+exclude = ["src/gtfs_diff/models.py", "src/gtfs_diff/_version.py"]
 
 [tool.ruff.lint]
 select = [
@@ -54,4 +54,4 @@ select = [
 ]
 
 [tool.ruff.format]
-exclude = ["src/gtfs_diff/models.py"]
+exclude = ["src/gtfs_diff/models.py", "src/gtfs_diff/_version.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "gtfs-diff-engine"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A diff engine for GTFS (General Transit Feed Specification) feeds"
 requires-python = ">=3.10"
 dependencies = [
@@ -25,6 +25,12 @@ dev = [
 
 [project.scripts]
 gtfs-diff = "gtfs_diff.cli:main"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/gtfs_diff/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gtfs_diff"]

--- a/src/gtfs_diff/__init__.py
+++ b/src/gtfs_diff/__init__.py
@@ -1,3 +1,8 @@
 """GTFS Diff Engine - compare two GTFS feeds and surface structured differences."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("gtfs-diff-engine")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/src/gtfs_diff/__init__.py
+++ b/src/gtfs_diff/__init__.py
@@ -1,6 +1,6 @@
 """GTFS Diff Engine - compare two GTFS feeds and surface structured differences."""
 
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("gtfs-diff-engine")

--- a/src/gtfs_diff/cli.py
+++ b/src/gtfs_diff/cli.py
@@ -11,7 +11,7 @@ from gtfs_diff.gtfs_definitions import DEFAULT_ID_CHURN_THRESHOLD
 
 
 @click.command()
-@click.version_option(version="0.1.0", prog_name="gtfs-diff-engine")
+@click.version_option(package_name="gtfs-diff-engine", prog_name="gtfs-diff-engine")
 @click.argument("base_feed", type=str)
 @click.argument("new_feed", type=str)
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,7 +38,7 @@ class TestVersion:
         runner = CliRunner()
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert "gtfs-diff-engine" in result.output
 
 
 class TestDiffToStdout:


### PR DESCRIPTION
  Switches from manually maintaining version numbers in source files to automatic versioning driven by git tags using `hatch-vcs`.
 
 ### Changes
 - Add `hatch-vcs` as a build dependency in `pyproject.toml`
 - Remove hardcoded `version` field; use `dynamic = ["version"]` instead
 - `__init__.py` now reads version from package metadata at runtime
 - CI release workflow uses `fetch-depth: 0` so `hatch-vcs` can resolve tags during build
 - Update version test to check program name instead of a hardcoded version string
 
 ### How to release going forward
 Create a GitHub Release with a tag like `v0.2.0` — the workflow picks it up and publishes that version to PyPI automatically. No more manual version bumps.

### Testing
This will be tested once merged and a release is done.